### PR TITLE
Add metric descriptions for Yield Inversion chart

### DIFF
--- a/dashboardfrontend/src/App.tsx
+++ b/dashboardfrontend/src/App.tsx
@@ -7,6 +7,7 @@ import React, {
     useState,
 } from 'react';
 import YieldInversionChart, { type YieldInversionChartHandle } from './YieldInversionChart';
+import MetricDescriptions from './MetricDescriptions';
 import { purgeCache } from './api';
 
 const STORAGE_KEY = 'yieldInversionSettings:v1';
@@ -222,13 +223,13 @@ export default function App() {
                     }}
                 >
                     <span style={{ fontSize: '.7rem', lineHeight: 1 }}>
-                        {navCollapsed ? '»' : '«'}
+                        {navCollapsed ? 'Â»' : 'Â«'}
                     </span>
                     {!navCollapsed && <span>Collapse</span>}
                 </button>
                 {!navCollapsed && (
                     <div style={{ fontSize: '.55rem', opacity: 0.55, marginTop: '.25rem' }}>
-                        v0.2 • enterprise zoom
+                        v0.2 â€¢ enterprise zoom
                     </div>
                 )}
             </aside>
@@ -357,7 +358,7 @@ export default function App() {
                             style={{ fontSize: '.6rem', padding: '.45rem .8rem', background: purging ? '#334054' : '#3d5a74', color: '#fff', border: '1px solid #4a6a86', borderRadius: 6, cursor: 'pointer' }}
                             title="Delete cached blobs and refetch data"
                         >
-                            {purging ? 'Purging…' : 'Purge Cache'}
+                            {purging ? 'Purgingâ€¦' : 'Purge Cache'}
                         </button>
                     </div>
                     {purgeError && (
@@ -418,6 +419,7 @@ export default function App() {
                                 reloadToken={reloadToken}
                             />
                         </div>
+                        <MetricDescriptions />
                     </div>
                 </div>
             </div>

--- a/dashboardfrontend/src/MetricDescriptions.tsx
+++ b/dashboardfrontend/src/MetricDescriptions.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+interface MetricDescription {
+    title: string;
+    description: string;
+}
+
+const defaultMetrics: MetricDescription[] = [
+    {
+        title: '10-Year Treasury Yield (DGS10)',
+        description: 'Average yield on U.S. Treasury bonds with a 10-year maturity, often viewed as a benchmark for long-term interest rates.',
+    },
+    {
+        title: '2-Year Treasury Yield (DGS2)',
+        description: 'Average yield on U.S. Treasury notes with a 2-year maturity, which tends to track expectations for near-term monetary policy.',
+    },
+    {
+        title: 'Yield Spread / Inversion',
+        description: 'The difference between the 10-year and 2-year yields. When the spread turns negative (short-term rates exceed long-term rates), the curve is said to be inverted—a pattern that has historically preceded recessions.',
+    },
+    {
+        title: 'GDP Growth (q/q SAAR %)',
+        description: 'Quarter-over-quarter change in real Gross Domestic Product, annualized and seasonally adjusted. This shows the pace of economic expansion or contraction. Future metrics may also track year-over-year changes.',
+    },
+];
+
+const MetricDescriptions: React.FC<{ items?: MetricDescription[] }> = ({ items = defaultMetrics }) => (
+    <div
+        style={{
+            fontSize: '.75rem',
+            marginTop: '.75rem',
+            lineHeight: 1.5,
+            color: 'var(--color-text)',
+            background: 'var(--color-surface-alt)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '.6rem .75rem',
+        }}
+    >
+        <div
+            style={{
+                fontSize: '.65rem',
+                textTransform: 'uppercase',
+                letterSpacing: '1px',
+                opacity: 0.85,
+                marginBottom: '.4rem',
+                color: 'var(--color-text-dim)',
+            }}
+        >
+            About the Metrics
+        </div>
+        <ul style={{ margin: 0, paddingLeft: '1.1rem' }}>
+            {items.map((m, idx) => (
+                <li key={idx} style={{ marginBottom: '.3rem' }}>
+                    <span style={{ color: 'var(--color-accent)' }}>{m.title}</span>: {m.description}
+                </li>
+            ))}
+        </ul>
+    </div>
+);
+
+export default MetricDescriptions;


### PR DESCRIPTION
## Summary
- add a `MetricDescriptions` component explaining 10y/2y yields, the spread, and GDP growth
- show the new description block beneath the Yield Inversion chart
- restyle the description block to use themed surface, border, and accent colors for better readability in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c762a2311883318ea54f41dc6e25a5