### PR TITLE
Fix Buffett indicator base CPI and enable PR tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,30 @@
+name: CI - Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '8.0.x'
+
+jobs:
+  test:
+    name: .NET unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Dashboard.sln
+
+      - name: Build
+        run: dotnet build Dashboard.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Dashboard.sln --configuration Release --no-build --no-restore

--- a/Dashboard.Functions.Tests/Services/BuffettIndicatorServiceTests.cs
+++ b/Dashboard.Functions.Tests/Services/BuffettIndicatorServiceTests.cs
@@ -1,0 +1,113 @@
+using DashboardFunctions.Domain;
+using DashboardFunctions.Services;
+using FluentAssertions;
+using System.Linq;
+
+namespace Dashboard.Functions.Tests.Services
+{
+    public class BuffettIndicatorServiceTests
+    {
+        private readonly BuffettIndicatorService _sut = new();
+
+        [Fact]
+        public void Compute_ReturnsExpectedRatiosAndForwardFill()
+        {
+            var market = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 1, 1), 20000m),
+                new SeriesPoint(new DateTime(2020, 1, 2), 21000m),
+            };
+            var gdp = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 1, 1), 21000m),
+                new SeriesPoint(new DateTime(2020, 4, 1), 20500m),
+            };
+            var sp = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 1, 1), 3000m),
+                new SeriesPoint(new DateTime(2020, 1, 2), 3050m),
+            };
+            var cpi = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 1, 1), 100m),
+                new SeriesPoint(new DateTime(2020, 2, 1), 101m),
+            };
+
+            var result = _sut.Compute(market, gdp, sp, cpi, new DateTime(2020, 1, 1), new DateTime(2020, 4, 1));
+
+            result.BasePriceIndex.Should().Be(100m);
+            result.BasePriceIndexDate.Should().Be(new DateTime(2020, 1, 1));
+            result.Points.Should().HaveCount(4);
+
+            var jan1 = result.Points[0];
+            jan1.Date.Should().Be(new DateTime(2020, 1, 1));
+            jan1.IndicatorPercent.Should().Be(95.24m);
+            jan1.EquityIndex.Should().Be(3000m);
+            jan1.EquityIndexReal.Should().Be(3000m);
+            jan1.EconomicOutputAsOf.Should().Be(new DateTime(2020, 1, 1));
+            jan1.PriceIndexAsOf.Should().Be(new DateTime(2020, 1, 1));
+
+            var jan2 = result.Points[1];
+            jan2.Date.Should().Be(new DateTime(2020, 1, 2));
+            jan2.IndicatorPercent.Should().Be(100m);
+            jan2.EquityIndex.Should().Be(3050m);
+            jan2.EquityIndexReal.Should().Be(3050m);
+
+            var feb1 = result.Points.Single(p => p.Date == new DateTime(2020, 2, 1));
+            feb1.EquityIndex.Should().Be(3050m);
+            feb1.EquityIndexReal.Should().Be(3019.80m);
+            feb1.PriceIndexAsOf.Should().Be(new DateTime(2020, 2, 1));
+
+            var apr1 = result.Points.Last();
+            apr1.Date.Should().Be(new DateTime(2020, 4, 1));
+            apr1.IndicatorPercent.Should().Be(102.44m);
+            apr1.EconomicOutput.Should().Be(20500m);
+            apr1.EconomicOutputAsOf.Should().Be(new DateTime(2020, 4, 1));
+        }
+
+        [Fact]
+        public void Compute_UsesLatestPriceIndexPriorToStartAsBase()
+        {
+            var market = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 2, 15), 22000m),
+            };
+            var gdp = new[]
+            {
+                new SeriesPoint(new DateTime(2019, 10, 1), 20500m),
+            };
+            var sp = new[]
+            {
+                new SeriesPoint(new DateTime(2020, 2, 15), 3400m),
+            };
+            var cpi = new[]
+            {
+                new SeriesPoint(new DateTime(2019, 12, 1), 99m),
+                new SeriesPoint(new DateTime(2020, 3, 1), 101m),
+            };
+
+            var result = _sut.Compute(market, gdp, sp, cpi, new DateTime(2020, 2, 15), new DateTime(2020, 3, 31));
+
+            result.BasePriceIndex.Should().Be(99m);
+            result.BasePriceIndexDate.Should().Be(new DateTime(2019, 12, 1));
+            result.Points.Should().ContainSingle();
+            result.Points[0].EquityIndexReal.Should().Be(3400m);
+        }
+
+        [Fact]
+        public void Compute_ReturnsEmptyWhenNoSeriesOverlap()
+        {
+            var result = _sut.Compute(
+                Array.Empty<SeriesPoint>(),
+                Array.Empty<SeriesPoint>(),
+                Array.Empty<SeriesPoint>(),
+                Array.Empty<SeriesPoint>(),
+                new DateTime(2021, 1, 1),
+                new DateTime(2021, 12, 31));
+
+            result.BasePriceIndex.Should().BeNull();
+            result.BasePriceIndexDate.Should().BeNull();
+            result.Points.Should().BeEmpty();
+        }
+    }
+}

--- a/DashboardFunctions/Functions/BuffettIndicatorFunction.cs
+++ b/DashboardFunctions/Functions/BuffettIndicatorFunction.cs
@@ -1,0 +1,89 @@
+using DashboardFunctions.Repositories;
+using DashboardFunctions.Services;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Net;
+using System.Text.Json;
+using System.Linq;
+
+namespace DashboardFunctions.Functions
+{
+    public sealed class BuffettIndicatorFunction(
+        ITimeSeriesFetchOrchestrator orchestrator,
+        ITimeSeriesRepositoryFactory repositoryFactory,
+        IBuffettIndicatorService service)
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+
+        [Function("GetBuffettIndicator")]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "buffett-indicator")] HttpRequestData req,
+            FunctionContext ctx)
+        {
+            var query = QueryHelpers.ParseQuery(req.Url.Query);
+            var startStr = query.TryGetValue("start", out var sVal) ? sVal.ToString() : null;
+            var endStr = query.TryGetValue("end", out var eVal) ? eVal.ToString() : null;
+
+            if (!DateTime.TryParse(startStr, out var start) || !DateTime.TryParse(endStr, out var end) || start > end)
+            {
+                var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+                await bad.WriteStringAsync("Provide valid start/end (YYYY-MM-DD). Example: ?start=1990-01-01&end=2024-12-31");
+                return bad;
+            }
+
+            var wilshireSeries = query.TryGetValue("marketCapSeries", out var mVal) ? mVal.ToString() : "WILL5000INDFC";
+            var gdpSeries = query.TryGetValue("outputSeries", out var gVal) ? gVal.ToString() : "GDP";
+            var spSeries = query.TryGetValue("equitySeries", out var s2Val) ? s2Val.ToString() : "SP500";
+            var cpiSeries = query.TryGetValue("priceSeries", out var pVal) ? pVal.ToString() : "CPIAUCSL";
+
+            var ct = ctx.CancellationToken;
+
+            await orchestrator.EnsureCachedAsync(wilshireSeries, start, end, ct);
+            await orchestrator.EnsureCachedAsync(gdpSeries, start, end, ct);
+            await orchestrator.EnsureCachedAsync(spSeries, start, end, ct);
+            await orchestrator.EnsureCachedAsync(cpiSeries, start, end, ct);
+
+            var repo = repositoryFactory.Resolve();
+
+            var market = await repo.GetSeriesAsync(wilshireSeries, start, end, ct);
+            var gdp = await repo.GetSeriesAsync(gdpSeries, start, end, ct);
+            var sp = await repo.GetSeriesAsync(spSeries, start, end, ct);
+            var cpi = await repo.GetSeriesAsync(cpiSeries, start, end, ct);
+
+            var result = service.Compute(market, gdp, sp, cpi, start, end);
+
+            var payload = new
+            {
+                start = start.ToString("yyyy-MM-dd"),
+                end = end.ToString("yyyy-MM-dd"),
+                marketCapSeries = wilshireSeries,
+                outputSeries = gdpSeries,
+                equitySeries = spSeries,
+                priceSeries = cpiSeries,
+                basePriceIndex = result.BasePriceIndex,
+                basePriceIndexDate = result.BasePriceIndexDate?.ToString("yyyy-MM-dd"),
+                points = result.Points.Select(p => new
+                {
+                    date = p.Date.ToString("yyyy-MM-dd"),
+                    marketCap = p.MarketCap,
+                    economicOutput = p.EconomicOutput,
+                    indicatorPercent = p.IndicatorPercent,
+                    equityIndex = p.EquityIndex,
+                    equityIndexReal = p.EquityIndexReal,
+                    economicOutputAsOf = p.EconomicOutputAsOf?.ToString("yyyy-MM-dd"),
+                    priceIndexAsOf = p.PriceIndexAsOf?.ToString("yyyy-MM-dd")
+                })
+            };
+
+            var ok = req.CreateResponse(HttpStatusCode.OK);
+            ok.Headers.Add("Content-Type", "application/json");
+            await ok.WriteStringAsync(JsonSerializer.Serialize(payload, JsonOptions), ct);
+            return ok;
+        }
+    }
+}

--- a/DashboardFunctions/Program.cs
+++ b/DashboardFunctions/Program.cs
@@ -47,6 +47,7 @@ var host = Host.CreateDefaultBuilder()
         services.AddScoped<IRangeService, RangeService>();
         services.AddScoped<IInversionService, InversionService>();
         services.AddScoped<ITimeSeriesFetchOrchestrator, TimeSeriesFetchOrchestrator>();
+        services.AddScoped<IBuffettIndicatorService, BuffettIndicatorService>();
     })
     .Build();
 

--- a/DashboardFunctions/Services/BuffettIndicatorService.cs
+++ b/DashboardFunctions/Services/BuffettIndicatorService.cs
@@ -1,0 +1,204 @@
+namespace DashboardFunctions.Services
+{
+    using DashboardFunctions.Domain;
+
+    internal sealed class BuffettIndicatorService : IBuffettIndicatorService
+    {
+        public BuffettIndicatorResult Compute(
+            IEnumerable<SeriesPoint> marketCap,
+            IEnumerable<SeriesPoint> economicOutput,
+            IEnumerable<SeriesPoint> equityIndex,
+            IEnumerable<SeriesPoint> priceIndex,
+            DateTime start,
+            DateTime end)
+        {
+            if (end < start)
+            {
+                (start, end) = (end, start);
+            }
+
+            var startDate = start.Date;
+            var endDate = end.Date;
+
+            var marketPoints = marketCap
+                .Where(p => p.Date <= endDate)
+                .OrderBy(p => p.Date)
+                .ToList();
+            var gdpPoints = economicOutput
+                .Where(p => p.Date <= endDate)
+                .OrderBy(p => p.Date)
+                .ToList();
+            var equityPoints = equityIndex
+                .Where(p => p.Date <= endDate)
+                .OrderBy(p => p.Date)
+                .ToList();
+            var pricePoints = priceIndex
+                .Where(p => p.Date <= endDate)
+                .OrderBy(p => p.Date)
+                .ToList();
+
+            var dateSet = new SortedSet<DateTime>();
+            foreach (var p in marketPoints)
+            {
+                if (p.Date >= startDate && p.Date <= endDate)
+                {
+                    dateSet.Add(p.Date);
+                }
+            }
+            foreach (var p in equityPoints)
+            {
+                if (p.Date >= startDate && p.Date <= endDate)
+                {
+                    dateSet.Add(p.Date);
+                }
+            }
+            foreach (var p in gdpPoints)
+            {
+                if (p.Date >= startDate && p.Date <= endDate)
+                {
+                    dateSet.Add(p.Date);
+                }
+            }
+            foreach (var p in pricePoints)
+            {
+                if (p.Date >= startDate && p.Date <= endDate)
+                {
+                    dateSet.Add(p.Date);
+                }
+            }
+
+            if (dateSet.Count == 0)
+            {
+                return new BuffettIndicatorResult(Array.Empty<BuffettIndicatorPoint>(), null, null);
+            }
+
+            var orderedDates = dateSet.ToList();
+            orderedDates.Sort();
+
+            var basePriceEntry = pricePoints
+                .LastOrDefault(p => p.Date <= startDate && p.Value.HasValue)
+                ?? pricePoints.FirstOrDefault(p => p.Value.HasValue);
+            var basePriceIndex = basePriceEntry?.Value;
+            var basePriceDate = basePriceEntry?.Date;
+
+            decimal? latestGdp = null;
+            DateTime? latestGdpDate = null;
+            decimal? latestPriceIndex = null;
+            DateTime? latestPriceDate = null;
+            decimal? currentMarketCap = null;
+            decimal? currentEquity = null;
+
+            var marketIdx = 0;
+            var gdpIdx = 0;
+            var equityIdx = 0;
+            var priceIdx = 0;
+
+            var firstDate = orderedDates[0];
+
+            while (gdpIdx < gdpPoints.Count && gdpPoints[gdpIdx].Date < firstDate)
+            {
+                var g = gdpPoints[gdpIdx++];
+                if (g.Value.HasValue)
+                {
+                    latestGdp = g.Value.Value;
+                    latestGdpDate = g.Date;
+                }
+            }
+
+            while (priceIdx < pricePoints.Count && pricePoints[priceIdx].Date < firstDate)
+            {
+                var c = pricePoints[priceIdx++];
+                if (c.Value.HasValue)
+                {
+                    latestPriceIndex = c.Value.Value;
+                    latestPriceDate = c.Date;
+                }
+            }
+
+            while (marketIdx < marketPoints.Count && marketPoints[marketIdx].Date < firstDate)
+            {
+                var m = marketPoints[marketIdx++];
+                if (m.Value.HasValue)
+                {
+                    currentMarketCap = m.Value.Value;
+                }
+            }
+
+            while (equityIdx < equityPoints.Count && equityPoints[equityIdx].Date < firstDate)
+            {
+                var e = equityPoints[equityIdx++];
+                if (e.Value.HasValue)
+                {
+                    currentEquity = e.Value.Value;
+                }
+            }
+
+            var results = new List<BuffettIndicatorPoint>(orderedDates.Count);
+
+            foreach (var date in orderedDates)
+            {
+                while (gdpIdx < gdpPoints.Count && gdpPoints[gdpIdx].Date <= date)
+                {
+                    var g = gdpPoints[gdpIdx++];
+                    if (g.Value.HasValue)
+                    {
+                        latestGdp = g.Value.Value;
+                        latestGdpDate = g.Date;
+                    }
+                }
+
+                while (priceIdx < pricePoints.Count && pricePoints[priceIdx].Date <= date)
+                {
+                    var c = pricePoints[priceIdx++];
+                    if (c.Value.HasValue)
+                    {
+                        latestPriceIndex = c.Value.Value;
+                        latestPriceDate = c.Date;
+                    }
+                }
+
+                while (marketIdx < marketPoints.Count && marketPoints[marketIdx].Date <= date)
+                {
+                    var m = marketPoints[marketIdx++];
+                    if (m.Value.HasValue)
+                    {
+                        currentMarketCap = m.Value.Value;
+                    }
+                }
+
+                while (equityIdx < equityPoints.Count && equityPoints[equityIdx].Date <= date)
+                {
+                    var e = equityPoints[equityIdx++];
+                    if (e.Value.HasValue)
+                    {
+                        currentEquity = e.Value.Value;
+                    }
+                }
+
+                decimal? ratio = null;
+                if (currentMarketCap.HasValue && latestGdp.HasValue && latestGdp.Value != 0m)
+                {
+                    ratio = Math.Round((currentMarketCap.Value / latestGdp.Value) * 100m, 2, MidpointRounding.AwayFromZero);
+                }
+
+                decimal? realEquity = null;
+                if (currentEquity.HasValue && latestPriceIndex.HasValue && basePriceIndex.HasValue && latestPriceIndex.Value != 0m)
+                {
+                    realEquity = Math.Round(currentEquity.Value * basePriceIndex.Value / latestPriceIndex.Value, 2, MidpointRounding.AwayFromZero);
+                }
+
+                results.Add(new BuffettIndicatorPoint(
+                    date,
+                    currentMarketCap,
+                    latestGdp,
+                    ratio,
+                    currentEquity,
+                    realEquity,
+                    latestGdpDate,
+                    latestPriceDate));
+            }
+
+            return new BuffettIndicatorResult(results, basePriceIndex, basePriceDate);
+        }
+    }
+}

--- a/DashboardFunctions/Services/IBuffettIndicatorService.cs
+++ b/DashboardFunctions/Services/IBuffettIndicatorService.cs
@@ -1,0 +1,30 @@
+namespace DashboardFunctions.Services
+{
+    using DashboardFunctions.Domain;
+
+    public interface IBuffettIndicatorService
+    {
+        BuffettIndicatorResult Compute(
+            IEnumerable<SeriesPoint> marketCap,
+            IEnumerable<SeriesPoint> economicOutput,
+            IEnumerable<SeriesPoint> equityIndex,
+            IEnumerable<SeriesPoint> priceIndex,
+            DateTime start,
+            DateTime end);
+    }
+
+    public sealed record BuffettIndicatorResult(
+        IReadOnlyList<BuffettIndicatorPoint> Points,
+        decimal? BasePriceIndex,
+        DateTime? BasePriceIndexDate);
+
+    public sealed record BuffettIndicatorPoint(
+        DateTime Date,
+        decimal? MarketCap,
+        decimal? EconomicOutput,
+        decimal? IndicatorPercent,
+        decimal? EquityIndex,
+        decimal? EquityIndexReal,
+        DateTime? EconomicOutputAsOf,
+        DateTime? PriceIndexAsOf);
+}

--- a/dashboardfrontend/src/App.tsx
+++ b/dashboardfrontend/src/App.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import YieldInversionReport from './reports/YieldInversion/YieldInversionReport';
 import JobsReport from './reports/Jobs/JobsReport';
+import BuffettIndicatorReport from './reports/BuffettIndicator/BuffettIndicatorReport';
 
 const NAV_KEY = 'yieldInversionSettings:navCollapsed:v1';
 const ACTIVE_REPORT_KEY = 'dashboard:lastReport:v1';
@@ -9,6 +10,7 @@ const ACTIVE_REPORT_KEY = 'dashboard:lastReport:v1';
 // Simple enum of report identifiers
 const reports = [
     { id: 'yield', label: 'Yield Inversion', component: <YieldInversionReport /> },
+    { id: 'buffett', label: 'Buffett Indicator', component: <BuffettIndicatorReport /> },
     { id: 'jobs', label: 'Jobs', component: <JobsReport /> },
 ];
 

--- a/dashboardfrontend/src/YieldInversionChart.tsx
+++ b/dashboardfrontend/src/YieldInversionChart.tsx
@@ -7,8 +7,9 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import { AgCharts } from 'ag-charts-react';
-import type { AgCartesianChartOptions, AgChartInstance } from 'ag-charts-community';
+import { AgChartsReact } from 'ag-charts-react';
+import type { AgChartsReactRef } from 'ag-charts-react';
+import type { AgCartesianChartOptions } from 'ag-charts-community';
 import { fetchInversion, fetchGdpGrowth } from './api';
 import type { YieldResponseDto, GdpGrowthResponseDto } from './types';
 
@@ -63,7 +64,7 @@ const YieldInversionChart = forwardRef<YieldInversionChartHandle, Props>(functio
         };
     }, []);
 
-    const agRef = useRef<{ chart?: AgChartInstance } | null>(null);
+    const agRef = useRef<AgChartsReactRef | null>(null);
     const initialStateRef = useRef<any | null>(null);
     const [resetNonce, setResetNonce] = useState(0);
 
@@ -90,7 +91,7 @@ const YieldInversionChart = forwardRef<YieldInversionChartHandle, Props>(functio
 
     // Capture initial chart state
     useEffect(() => {
-        const inst = agRef.current?.chart as any;
+        const inst = agRef.current?.chart;
         if (inst && typeof inst.getState === 'function') {
             try { initialStateRef.current = inst.getState(); } catch { }
         }
@@ -98,7 +99,7 @@ const YieldInversionChart = forwardRef<YieldInversionChartHandle, Props>(functio
 
     useImperativeHandle(ref, () => ({
         resetZoom() {
-            const inst = agRef.current?.chart as any;
+            const inst = agRef.current?.chart;
             // Prefer API reset via setState if available (v9/10+)
             if (inst && typeof inst.setState === 'function') {
                 const zoomState = initialStateRef.current?.zoom;
@@ -112,13 +113,13 @@ const YieldInversionChart = forwardRef<YieldInversionChartHandle, Props>(functio
         },
         // Optional helpers if you later want to persist state:
         saveState() {
-            const inst = agRef.current?.chart as any;
+            const inst = agRef.current?.chart;
             if (inst && typeof inst.getState === 'function') {
                 initialStateRef.current = inst.getState();
             }
         },
         restoreState() {
-            const inst = agRef.current?.chart as any;
+            const inst = agRef.current?.chart;
             const st = initialStateRef.current;
             if (inst && typeof inst.setState === 'function' && st) {
                 inst.setState(st);
@@ -289,7 +290,7 @@ const YieldInversionChart = forwardRef<YieldInversionChartHandle, Props>(functio
 
     return (
         <div style={{ flex: 1, minWidth: 0, width: '100%', height: '100%', minHeight: 0, display: 'flex' }}>
-            <AgCharts ref={agRef as any} options={options as any} style={{ flex: 1, minWidth: 0 }} />
+            <AgChartsReact ref={agRef} options={options as any} style={{ flex: 1, minWidth: 0 }} />
         </div>
     );
 });

--- a/dashboardfrontend/src/api.ts
+++ b/dashboardfrontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { YieldResponseDto, GdpGrowthResponseDto, JobsDataResponseDto } from './types';
+import type { YieldResponseDto, GdpGrowthResponseDto, JobsDataResponseDto, BuffettIndicatorResponseDto } from './types';
 
 interface EnvShape { VITE_API_BASE?: string; VITE_API_KEY?: string; }
 function getEnv(): EnvShape {
@@ -68,6 +68,33 @@ export async function fetchJobsData(
     throw new Error(`HTTP ${res.status}: ${text}`);
   }
   return await res.json() as JobsDataResponseDto;
+}
+
+interface BuffettIndicatorOptions {
+  marketCapSeries?: string;
+  outputSeries?: string;
+  equitySeries?: string;
+  priceSeries?: string;
+}
+
+export async function fetchBuffettIndicator(
+  start: string,
+  end: string,
+  options?: BuffettIndicatorOptions
+): Promise<BuffettIndicatorResponseDto> {
+  const base = resolveApiBase();
+  const params = new URLSearchParams({ start, end });
+  if (options?.marketCapSeries) params.set('marketCapSeries', options.marketCapSeries);
+  if (options?.outputSeries) params.set('outputSeries', options.outputSeries);
+  if (options?.equitySeries) params.set('equitySeries', options.equitySeries);
+  if (options?.priceSeries) params.set('priceSeries', options.priceSeries);
+  const url = appendCode(`${base}/api/buffett-indicator?${params.toString()}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+  return await res.json() as BuffettIndicatorResponseDto;
 }
 
 // DELETE selected cache blobs (coverage + specified observation blobs)

--- a/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorMetricDescriptions.tsx
+++ b/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorMetricDescriptions.tsx
@@ -1,0 +1,56 @@
+const cards = [
+  {
+    title: 'Buffett Indicator (Wilshire 5000 / GDP)',
+    body: 'Total U.S. public equity market capitalization divided by U.S. economic output. Buffett called it “probably the best single measure” of aggregate equity valuation in a 2001 Fortune essay.',
+  },
+  {
+    title: 'Rule-of-thumb bands',
+    body: 'Below ~80% is often viewed as discounted, 80–120% as fair-ish, and above 120% increasingly expensive. Once valuations push toward ~200% Buffett warned investors were “playing with fire.” These are heuristics, not rigid triggers.',
+  },
+  {
+    title: 'Global revenue vs. domestic GDP',
+    body: 'Large U.S. companies sell globally, so market cap reflects worldwide opportunity while GDP is domestic. This structural shift tends to push the ratio higher over long horizons.',
+  },
+  {
+    title: 'Measurement drift & comparability',
+    body: 'Intangibles, digital goods, and the public/private mix change what both “market cap” and “GDP” capture. Ratios across decades or countries should be compared cautiously.',
+  },
+  {
+    title: 'Inflation-adjusted S&P 500 overlay',
+    body: 'The blue line deflates the S&P 500 using CPI so price moves reflect real purchasing power. Toggle the nominal line to compare headline vs. real pricing.',
+  },
+];
+
+export default function BuffettIndicatorMetricDescriptions() {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: '.75rem',
+        gridTemplateColumns: 'repeat(auto-fit,minmax(220px,1fr))',
+      }}
+    >
+      {cards.map(card => (
+        <div
+          key={card.title}
+          style={{
+            position: 'relative',
+            padding: '.85rem .9rem .95rem',
+            borderRadius: 'var(--radius-lg, 16px)',
+            background: 'linear-gradient(145deg, rgba(30,42,56,.78), rgba(14,20,28,.88))',
+            border: '1px solid var(--color-border, rgba(120,160,190,0.18))',
+            color: 'var(--color-text, #d2dde7)',
+            fontSize: '.7rem',
+            lineHeight: 1.45,
+            boxShadow: '0 2px 4px -2px rgba(0,0,0,.35)',
+          }}
+        >
+          <div style={{ fontSize: '.72rem', fontWeight: 600, letterSpacing: '.4px', marginBottom: '.35rem', color: 'var(--color-accent, #38bdf8)' }}>
+            {card.title}
+          </div>
+          <div>{card.body}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorReport.tsx
+++ b/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorReport.tsx
@@ -1,0 +1,301 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { AgChartsReact } from 'ag-charts-react';
+import type { AgCartesianChartOptions } from 'ag-charts-community';
+import { fetchBuffettIndicator } from '../../api';
+import type { BuffettIndicatorResponseDto } from '../../types';
+import BuffettIndicatorMetricDescriptions from './BuffettIndicatorMetricDescriptions';
+
+const SETTINGS_KEY = 'buffettIndicatorSettings:v1';
+
+interface PersistedSettings {
+  start: string;
+  end: string;
+  showNominal: boolean;
+  showReal: boolean;
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function loadInitial(): PersistedSettings {
+  const fallback: PersistedSettings = {
+    start: '1990-01-01',
+    end: todayIso(),
+    showNominal: false,
+    showReal: true,
+  };
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return fallback;
+    const { start, end, showNominal, showReal } = parsed as any;
+    const iso = /^\d{4}-\d{2}-\d{2}$/;
+    return {
+      start: iso.test(start) ? start : fallback.start,
+      end: iso.test(end) ? end : fallback.end,
+      showNominal: typeof showNominal === 'boolean' ? showNominal : fallback.showNominal,
+      showReal: typeof showReal === 'boolean' ? showReal : fallback.showReal,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function classifyRatio(value: number | null | undefined): { label: string; tone: string } {
+  if (value == null || Number.isNaN(value)) {
+    return { label: 'N/A', tone: '#9ca3af' };
+  }
+  if (value < 80) return { label: '< 80% • historically cheap territory', tone: '#34d399' };
+  if (value < 120) return { label: '80-120% • closer to long-run averages', tone: '#facc15' };
+  if (value < 200) return { label: '120-200% • stretched valuations', tone: '#f97316' };
+  return { label: '200%+ • “playing with fire” zone', tone: '#ef4444' };
+}
+
+export default function BuffettIndicatorReport() {
+  const init = useMemo(loadInitial, []);
+  const [start, setStart] = useState(init.start);
+  const [end, setEnd] = useState(init.end);
+  const [startInput, setStartInput] = useState(init.start);
+  const [endInput, setEndInput] = useState(init.end);
+  const [showNominal, setShowNominal] = useState(init.showNominal);
+  const [showReal, setShowReal] = useState(init.showReal);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mqWidth = window.matchMedia('(max-width: 820px)');
+    const mqCoarse = window.matchMedia('(pointer: coarse)');
+    const update = () => setIsMobile(mqWidth.matches || mqCoarse.matches);
+    update();
+    mqWidth.addEventListener('change', update);
+    mqCoarse.addEventListener('change', update);
+    return () => {
+      mqWidth.removeEventListener('change', update);
+      mqCoarse.removeEventListener('change', update);
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        SETTINGS_KEY,
+        JSON.stringify({ start, end, showNominal, showReal })
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [start, end, showNominal, showReal]);
+
+  const isValidDate = useCallback((v: string) => /^\d{4}-\d{2}-\d{2}$/.test(v) && !Number.isNaN(new Date(v + 'T00:00:00').getTime()), []);
+  const maybeCommitStart = useCallback((v: string) => { if (v.length === 10 && isValidDate(v)) setStart(v); }, [isValidDate]);
+  const maybeCommitEnd = useCallback((v: string) => { if (v.length === 10 && isValidDate(v)) setEnd(v); }, [isValidDate]);
+
+  const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    setStartInput(v);
+    maybeCommitStart(v);
+  };
+  const handleEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    setEndInput(v);
+    maybeCommitEnd(v);
+  };
+  const handleStartBlur = () => {
+    if (!isValidDate(startInput)) { setStartInput(start); return; }
+    setStart(startInput);
+  };
+  const handleEndBlur = () => {
+    if (!isValidDate(endInput)) { setEndInput(end); return; }
+    setEnd(endInput);
+  };
+
+  const [resp, setResp] = useState<BuffettIndicatorResponseDto | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchBuffettIndicator(start, end)
+      .then(r => { if (!cancelled) setResp(r); })
+      .catch(e => { if (!cancelled) setError(String(e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [start, end, reloadToken]);
+
+  const chartData = useMemo(() => {
+    if (!resp) return [] as Array<Record<string, any>>;
+    return resp.points.map(p => ({
+      date: new Date(p.date + 'T12:00:00Z'),
+      ratio: p.indicatorPercent,
+      sp500: p.equityIndex,
+      sp500Real: p.equityIndexReal,
+    }));
+  }, [resp]);
+
+  const ratioExtent = useMemo(() => {
+    const vals = chartData.map(d => d.ratio).filter((v): v is number => typeof v === 'number' && !Number.isNaN(v));
+    if (!vals.length) return undefined;
+    const min = Math.min(...vals);
+    const max = Math.max(...vals);
+    const padding = (max - min) * 0.1 || 10;
+    return {
+      min: Math.max(0, Math.floor((min - padding) * 10) / 10),
+      max: Math.ceil((max + padding) * 10) / 10,
+    };
+  }, [chartData]);
+
+  const series = useMemo(() => {
+    const lines: AgCartesianChartOptions['series'] = [
+      {
+        type: 'line',
+        xKey: 'date',
+        yKey: 'ratio',
+        yName: 'Buffett Indicator (%)',
+        yAxisKey: 'ratioAxis',
+        stroke: '#f97316',
+        strokeWidth: 2.5,
+        marker: { enabled: false },
+        tooltip: {
+          renderer: ({ datum }) => ({
+            content: `Buffett Indicator: ${datum.ratio != null ? datum.ratio.toFixed(2) + '%' : 'n/a'}`,
+          }),
+        },
+      } as any,
+    ];
+    if (showReal) {
+      lines.push({
+        type: 'line',
+        xKey: 'date',
+        yKey: 'sp500Real',
+        yName: 'S&P 500 (real)',
+        yAxisKey: 'equityAxis',
+        stroke: '#60a5fa',
+        strokeWidth: 2,
+        marker: { enabled: false },
+      } as any);
+    }
+    if (showNominal) {
+      lines.push({
+        type: 'line',
+        xKey: 'date',
+        yKey: 'sp500',
+        yName: 'S&P 500 (nominal)',
+        yAxisKey: 'equityAxis',
+        stroke: '#a855f7',
+        strokeWidth: 1.5,
+        strokeOpacity: 0.75,
+        marker: { enabled: false },
+      } as any);
+    }
+    return lines;
+  }, [showNominal, showReal]);
+
+  const options = useMemo<AgCartesianChartOptions>(() => ({
+    theme: 'ag-default-dark',
+    background: { fill: 'transparent' },
+    data: chartData,
+    axes: [
+      { type: 'time', position: 'bottom', label: { format: '%Y', minSpacing: 12 }, nice: false, gridLine: { enabled: true } },
+      {
+        type: 'number',
+        position: 'left',
+        keys: ['ratio'],
+        title: { text: 'Buffett Indicator (%)' },
+        nice: true,
+        ...(ratioExtent || {}),
+        id: 'ratioAxis',
+      },
+      {
+        type: 'number',
+        position: 'right',
+        keys: ['sp500', 'sp500Real'],
+        title: { text: 'S&P 500 Index' },
+        nice: true,
+        gridLine: { enabled: false },
+        id: 'equityAxis',
+      },
+    ],
+    legend: { enabled: true, position: isMobile ? 'top' : 'bottom', item: { marker: { size: isMobile ? 8 : 12 } } },
+    series,
+    zoom: { enabled: true, axes: 'x', enablePanning: true, enableScrolling: true } as any,
+    padding: isMobile ? { top: 8, right: 12, bottom: 4, left: 12 } : { top: 12, right: 16, bottom: 8, left: 18 },
+  }), [chartData, series, ratioExtent, isMobile]);
+
+  const latestPoint = useMemo(() => {
+    if (!resp) return null;
+    for (let i = resp.points.length - 1; i >= 0; i -= 1) {
+      const p = resp.points[i];
+      if (p.indicatorPercent != null) return p;
+    }
+    return null;
+  }, [resp]);
+
+  const ratioSummary = useMemo(() => classifyRatio(latestPoint?.indicatorPercent ?? null), [latestPoint]);
+
+  const resetRange = () => {
+    const defaults = loadInitial();
+    setStart(defaults.start);
+    setEnd(defaults.end);
+    setStartInput(defaults.start);
+    setEndInput(defaults.end);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', padding: '.65rem 1rem', background: 'rgba(18,25,33,.85)', borderBottom: '1px solid #243241', alignItems: 'flex-end' }}>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <label style={{ fontSize: '.6rem', textTransform: 'uppercase', letterSpacing: '1px', opacity: 0.7 }}>Start</label>
+          <input type='date' value={startInput} onChange={handleStartChange} onBlur={handleStartBlur} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <label style={{ fontSize: '.6rem', textTransform: 'uppercase', letterSpacing: '1px', opacity: 0.7 }}>End</label>
+          <input type='date' value={endInput} onChange={handleEndChange} onBlur={handleEndBlur} />
+        </div>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '.4rem', fontSize: '.6rem', cursor: 'pointer' }}>
+          <input type='checkbox' checked={showReal} onChange={e => setShowReal(e.target.checked)} /> Show real (inflation-adjusted) S&P 500
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '.4rem', fontSize: '.6rem', cursor: 'pointer' }}>
+          <input type='checkbox' checked={showNominal} onChange={e => setShowNominal(e.target.checked)} /> Show nominal S&P 500
+        </label>
+        <button onClick={() => setReloadToken(t => t + 1)} style={{ fontSize: '.6rem', padding: '.45rem .8rem', marginLeft: 'auto' }}>Reload</button>
+        <button onClick={resetRange} style={{ fontSize: '.6rem', padding: '.45rem .8rem' }}>Reset Range</button>
+      </div>
+      <div style={{ flex: 1, minHeight: 0, padding: '.75rem', display: 'flex', overflow: 'hidden' }}>
+        <div style={{ flex: 1, minHeight: 0, minWidth: 0, background: 'linear-gradient(145deg,#1d2731,#10161c)', border: '1px solid #243241', borderRadius: 12, padding: '.6rem', display: 'flex', flexDirection: 'column', height: '100%', overflowY: isMobile ? 'auto' : 'visible' }}>
+          <div style={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', gap: '.75rem', alignItems: isMobile ? 'flex-start' : 'center', justifyContent: 'space-between', marginBottom: '.4rem' }}>
+            <div style={{ fontSize: '.65rem', textTransform: 'uppercase', letterSpacing: '1px', opacity: 0.7 }}>Buffett Indicator vs. S&P 500</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.65rem' }}>
+              <div style={{ fontSize: '.65rem', color: 'var(--color-text-dim, #9ca3af)' }}>
+                Latest reading: {latestPoint ? `${latestPoint.indicatorPercent?.toFixed(2)}% (${latestPoint.date})` : '—'}
+              </div>
+              <div style={{ fontSize: '.65rem', color: ratioSummary.tone }}>
+                {ratioSummary.label}
+              </div>
+            </div>
+          </div>
+          <div style={{ flex: isMobile ? '0 0 90%' : '1 1 auto', height: isMobile ? '90%' : undefined, minHeight: 0, minWidth: 0, display: 'flex' }}>
+            {error && <div style={{ color: '#f87171', fontSize: '.7rem' }}>{error}</div>}
+            {loading && !resp && <div style={{ color: 'var(--color-text-dim)', fontSize: '.7rem' }}>Loading…</div>}
+            {resp && <AgChartsReact options={options as any} style={{ flex: 1, minWidth: 0 }} />}
+          </div>
+          <div style={{ flex: '0 0 auto', marginTop: isMobile ? '.4rem' : '.6rem', display: 'flex', flexDirection: 'column', gap: '.6rem' }}>
+            {resp && (
+              <div style={{ fontSize: '.6rem', opacity: 0.7, display: 'flex', flexDirection: 'column', gap: '.25rem' }}>
+                <span>Market cap series: {resp.marketCapSeries} • GDP series: {resp.outputSeries}</span>
+                <span>S&P source: {resp.equitySeries} • CPI series: {resp.priceSeries}</span>
+                {resp.basePriceIndex != null && resp.basePriceIndexDate && (
+                  <span>Real S&P rebased to CPI {resp.basePriceIndexDate} = {resp.basePriceIndex.toFixed(2)}</span>
+                )}
+              </div>
+            )}
+            <BuffettIndicatorMetricDescriptions />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboardfrontend/src/reports/Jobs/JobsReport.tsx
+++ b/dashboardfrontend/src/reports/Jobs/JobsReport.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fetchJobsData } from '../../api';
 import type { JobsDataResponseDto } from '../../types';
-import { AgCharts } from 'ag-charts-react';
-import type { AgCartesianChartOptions, AgChartInstance } from 'ag-charts-community';
+import { AgChartsReact } from 'ag-charts-react';
+import type { AgChartsReactRef } from 'ag-charts-react';
+import type { AgCartesianChartOptions } from 'ag-charts-community';
 import JobsMetricDescriptions from './JobsMetricDescriptions';
 
 // Stable series color mapping so toggling visibility preserves color identity
@@ -178,7 +179,7 @@ export default function JobsReport() {
     }
   }, [changeMode]);
 
-  const chartRef = useRef<{ chart?: AgChartInstance } | null>(null);
+  const chartRef = useRef<AgChartsReactRef | null>(null);
 
   const options = useMemo<AgCartesianChartOptions>(() => ({
     theme: 'ag-default-dark',
@@ -238,7 +239,8 @@ export default function JobsReport() {
           <div style={{ fontSize:'.65rem', textTransform:'uppercase', letterSpacing:'1px', opacity:.7, marginBottom:'.4rem', flex:'0 0 auto' }}>Labor Market Series</div>
           <div style={{ flex: isMobile ? '0 0 90%' : '1 1 auto', height: isMobile ? '90%' : undefined, minHeight:0, minWidth:0, display:'flex' }}>
             {error && <div style={{ color:'#f87171', fontSize:'.7rem' }}>{error}</div>}
-            {loading && !resp && <div style={{ color:'var(--color-text-dim)', fontSize:'.7rem' }}>Loading…</div>}
+            {resp && <AgChartsReact ref={chartRef} options={options as any} style={{ flex:1, minWidth:0 }} />}
+</div>}
             {resp && <AgCharts ref={chartRef as any} options={options as any} style={{ flex:1, minWidth:0 }} />}
           </div>
           <div style={{ flex:'0 0 auto', marginTop:isMobile?'.4rem':'.6rem' }}>

--- a/dashboardfrontend/src/types.ts
+++ b/dashboardfrontend/src/types.ts
@@ -41,3 +41,26 @@ export type JobsDataResponseDto = {
   series: JobsSeriesMeta[];
   points: JobsPointDto[];
 };
+
+export type BuffettIndicatorPointDto = {
+  date: string;
+  marketCap: number | null;
+  economicOutput: number | null;
+  indicatorPercent: number | null;
+  equityIndex: number | null;
+  equityIndexReal: number | null;
+  economicOutputAsOf?: string | null;
+  priceIndexAsOf?: string | null;
+};
+
+export type BuffettIndicatorResponseDto = {
+  start: string;
+  end: string;
+  marketCapSeries: string;
+  outputSeries: string;
+  equitySeries: string;
+  priceSeries: string;
+  basePriceIndex: number | null;
+  basePriceIndexDate?: string | null;
+  points: BuffettIndicatorPointDto[];
+};


### PR DESCRIPTION
## Summary
- ensure the Buffett indicator service rebases real index values to the latest CPI prior to the requested range and cover edge cases with new unit tests
- switch React chart components to the supported `AgChartsReact` wrapper
- add a pull-request GitHub Actions workflow that restores, builds, and runs the .NET unit tests

## Testing
- `npm install --prefix dashboardfrontend` *(fails: 403 Forbidden when downloading npm packages in the environment)*
- `dotnet test` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0d902360833198760abcd0c359cc