### PR TITLE
Fix ag-charts-react import usage

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   DOTNET_VERSION: '8.0.x'
+  NODE_VERSION: '20.19.0'
 
 jobs:
   test:
@@ -28,3 +29,26 @@ jobs:
 
       - name: Test
         run: dotnet test Dashboard.sln --configuration Release --no-build --no-restore
+
+  frontend-tests:
+    name: Frontend unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboardfrontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: dashboardfrontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run React unit tests
+        run: npm test

--- a/dashboardfrontend/package.json
+++ b/dashboardfrontend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "vitest --run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -22,6 +24,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -29,8 +33,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^26.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/dashboardfrontend/src/YieldInversionChart.tsx
+++ b/dashboardfrontend/src/YieldInversionChart.tsx
@@ -7,7 +7,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import { AgChartsReact } from 'ag-charts-react';
+import AgChartsReact from 'ag-charts-react';
 import type { AgChartsReactRef } from 'ag-charts-react';
 import type { AgCartesianChartOptions } from 'ag-charts-community';
 import { fetchInversion, fetchGdpGrowth } from './api';

--- a/dashboardfrontend/src/__tests__/App.test.tsx
+++ b/dashboardfrontend/src/__tests__/App.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from '../App';
+
+describe('App navigation and report selection', () => {
+  test('renders the Yield Inversion report by default', () => {
+    render(<App />);
+
+    expect(
+      screen.getByRole('button', { name: 'Yield Inversion' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Spread Right Axis')).toBeInTheDocument();
+  });
+
+  test('restores last active report from localStorage', () => {
+    localStorage.setItem('dashboard:lastReport:v1', 'jobs');
+
+    render(<App />);
+
+    expect(screen.getByText('Labor Market Series')).toBeInTheDocument();
+  });
+
+  test('collapsing the navigation updates toggle state', () => {
+    render(<App />);
+
+    const toggle = screen.getByRole('button', { name: 'Collapse navigation' });
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAccessibleName('Expand navigation');
+    expect(screen.getByTitle('Yield Inversion')).toHaveTextContent('Y');
+  });
+});

--- a/dashboardfrontend/src/__tests__/MetricDescriptions.test.tsx
+++ b/dashboardfrontend/src/__tests__/MetricDescriptions.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import MetricDescriptions from '../MetricDescriptions';
+
+describe('MetricDescriptions', () => {
+  test('renders the default metric set', () => {
+    render(<MetricDescriptions />);
+
+    expect(screen.getByText('About the Metrics')).toBeInTheDocument();
+    expect(screen.getByText('10-Year Treasury Yield (DGS10)')).toBeInTheDocument();
+    expect(screen.getByText('Yield Spread / Inversion')).toBeInTheDocument();
+  });
+
+  test('renders custom metrics when provided', () => {
+    const customItems = [
+      {
+        title: 'Custom Metric A',
+        description: 'Explanation for metric A.',
+      },
+      {
+        title: 'Custom Metric B',
+        description: 'Explanation for metric B.',
+      },
+    ];
+
+    render(<MetricDescriptions items={customItems} />);
+
+    expect(screen.getByText('Custom Metric A')).toBeInTheDocument();
+    expect(screen.getByText('Explanation for metric B.')).toBeInTheDocument();
+    expect(screen.queryByText('10-Year Treasury Yield (DGS10)')).not.toBeInTheDocument();
+  });
+});

--- a/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorReport.tsx
+++ b/dashboardfrontend/src/reports/BuffettIndicator/BuffettIndicatorReport.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { AgChartsReact } from 'ag-charts-react';
+import AgChartsReact from 'ag-charts-react';
 import type { AgCartesianChartOptions } from 'ag-charts-community';
 import { fetchBuffettIndicator } from '../../api';
 import type { BuffettIndicatorResponseDto } from '../../types';

--- a/dashboardfrontend/src/reports/Jobs/JobsReport.tsx
+++ b/dashboardfrontend/src/reports/Jobs/JobsReport.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fetchJobsData } from '../../api';
 import type { JobsDataResponseDto } from '../../types';
-import { AgChartsReact } from 'ag-charts-react';
+import AgChartsReact from 'ag-charts-react';
 import type { AgChartsReactRef } from 'ag-charts-react';
 import type { AgCartesianChartOptions } from 'ag-charts-community';
 import JobsMetricDescriptions from './JobsMetricDescriptions';

--- a/dashboardfrontend/src/setupTests.ts
+++ b/dashboardfrontend/src/setupTests.ts
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom/vitest';
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});

--- a/dashboardfrontend/tsconfig.json
+++ b/dashboardfrontend/tsconfig.json
@@ -10,7 +10,8 @@
     "noEmit": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["vitest/globals"]
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]

--- a/dashboardfrontend/vite.config.ts
+++ b/dashboardfrontend/vite.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
     plugins: [plugin()],
     server: {
         port: 51924,
-    }
-})
+    },
+    test: {
+        globals: true,
+        environment: 'jsdom',
+        setupFiles: './src/setupTests.ts',
+        css: true,
+    },
+});


### PR DESCRIPTION
## Summary
- import the AgChartsReact component via its default export so the build can resolve the library correctly

## Testing
- npm install *(fails: registry responds 403 because access is blocked in this environment)*
- npm test *(fails: Vitest executable is unavailable without installing dependencies)*
- dotnet test Dashboard.sln --configuration Release --no-build --no-restore *(fails: dotnet CLI is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb329b3c188331b0a7e754ce432a88