### PR TITLE
Fix AgChartsReact named import usage

### DIFF
--- a/dashboardfrontend/src/YieldInversionChart.tsx
+++ b/dashboardfrontend/src/YieldInversionChart.tsx
@@ -7,7 +7,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import AgChartsReact from 'ag-charts-react';
+import { AgChartsReact } from 'ag-charts-react';
 import type { AgChartsReactRef } from 'ag-charts-react';
 import type { AgCartesianChartOptions } from 'ag-charts-community';
 import { fetchInversion, fetchGdpGrowth } from './api';


### PR DESCRIPTION
## Summary
- update YieldInversionChart to use the named AgChartsReact export to match the library API

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68cb383987c483319e407b7fb0885572